### PR TITLE
unzipEncryptIfNeeded, unzipSelectedFile 추가

### DIFF
--- a/src/main/kotlin/com/ridi/books/helper/io/EncryptException.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/EncryptException.kt
@@ -1,5 +1,0 @@
-package com.ridi.books.helper.io
-
-open class EncryptException(message: String) : Exception(message)
-class EncryptFailException(fileName: String) : EncryptException("error while encrypt $fileName")
-class EncryptUnnecessaryException(fileName: String) : EncryptException("$fileName is unnecessary for encrypt")

--- a/src/main/kotlin/com/ridi/books/helper/io/EncryptException.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/EncryptException.kt
@@ -1,3 +1,5 @@
 package com.ridi.books.helper.io
 
-class EncryptException(fileName: String) : Exception("error while encrypt $fileName")
+open class EncryptException(message: String) : Exception(message)
+class EncryptFailException(fileName: String) : EncryptException("error while encrypt $fileName")
+class EncryptUnnecessaryException(fileName: String) : EncryptException("$fileName is unnecessary for encrypt")

--- a/src/main/kotlin/com/ridi/books/helper/io/EncryptException.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/EncryptException.kt
@@ -1,0 +1,3 @@
+package com.ridi.books.helper.io
+
+class EncryptException(fileName: String) : Exception("error while encrypt $fileName")

--- a/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
@@ -96,10 +96,10 @@ object ZipHelper {
                     try {
                         encryptor.encrypt(zipInputStream, out, file.name)
                         continue
-                    } catch (e: EncryptFailException) {
+                    } catch (e: EncryptionFailedException) {
                         out.close()
                         return false
-                    } catch (e: EncryptUnnecessaryException) {}
+                    } catch (e: EncryptionUnnecessaryException) {}
                 }
 
                 do {
@@ -127,3 +127,6 @@ object ZipHelper {
         }
     }
 }
+
+class EncryptionFailedException(fileName: String) : Exception("error while encrypt $fileName")
+class EncryptionUnnecessaryException(fileName: String) : Exception("$fileName is unnecessary for encrypt")

--- a/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
@@ -19,7 +19,7 @@ object ZipHelper {
     }
 
     interface Encryptor {
-        fun onEncrypt(zipArchiveInputStream: ZipArchiveInputStream, outputStream: OutputStream, fileName: String): EncryptResult
+        fun encrypt(zipArchiveInputStream: ZipArchiveInputStream, outputStream: OutputStream, fileName: String): EncryptResult
     }
 
     @JvmStatic
@@ -96,14 +96,14 @@ object ZipHelper {
                 var readSize: Int
                 val prevBytesRead = zipInputStream.bytesRead
                 if (encryptor != null) {
-                    val result = encryptor.onEncrypt(zipInputStream, out, file.name)
-                    if (isEncryptSuccess(result)) {
+                    val result = encryptor.encrypt(zipInputStream, out, file.name)
+                    if (result == EncryptResult.FAIL) {
                         if (result == EncryptResult.SUCCESS) {
                             continue
                         }
                     } else {
                         out.close()
-                        return false
+                        throw EncryptException(file.name)
                     }
                 }
 
@@ -131,6 +131,4 @@ object ZipHelper {
             zipInputStream.close()
         }
     }
-
-    private fun isEncryptSuccess(encryptResult: EncryptResult): Boolean = (encryptResult == EncryptResult.FAIL).not()
 }

--- a/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
@@ -15,7 +15,7 @@ object ZipHelper {
     }
 
     interface Encryptor {
-        @Throws(EncryptUnnecessaryException::class, EncryptFailException::class)
+        @Throws(EncryptionUnnecessaryException::class, EncryptionFailedException::class)
         fun encrypt(zipArchiveInputStream: ZipArchiveInputStream, outputStream: OutputStream, fileName: String)
     }
 

--- a/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
@@ -11,7 +11,7 @@ object ZipHelper {
     private val progressUpdateStepSize = bufferSize / 16
 
     enum class EncryptResult {
-        SUCCESS, FAIL, UNNECESSARY, FINISH
+        SUCCESS, FAIL, UNNECESSARY
     }
 
     interface Listener {
@@ -65,7 +65,6 @@ object ZipHelper {
         val zipInputStream = ZipArchiveInputStream(inputStream, encoding, true, true)
         try {
             var entry: ZipArchiveEntry?
-            var encryptFinish = false
             while (true) {
                 try {
                     entry = zipInputStream.nextZipEntry
@@ -80,10 +79,8 @@ object ZipHelper {
                     continue
                 }
 
-                if (selectedFileName != null) {
-                    if (entry.name != selectedFileName) {
-                        continue
-                    }
+                if (selectedFileName?.equals(entry.name) == false) {
+                    continue
                 }
 
                 val file = File(destDir, entry.name)
@@ -100,15 +97,13 @@ object ZipHelper {
                 val buf = ByteArray(bufferSize)
                 var readSize: Int
                 val prevBytesRead = zipInputStream.bytesRead
-                if (encryptor != null && encryptFinish.not()) {
+                if (encryptor != null) {
                     val result = encryptor.onEncrypt(zipInputStream, out, file.name)
                     if (result == EncryptResult.FAIL) {
                         out.close()
                         return false
                     } else if (result == EncryptResult.SUCCESS) {
                         continue
-                    } else if (result == EncryptResult.FINISH) {
-                        encryptFinish = true
                     }
                 }
 

--- a/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
@@ -30,12 +30,10 @@ object ZipHelper {
             return false
         }
         return try {
-            var result = false
-            encodings.forEach {
-                result = unzip(BufferedInputStream(FileInputStream(zipFile)),
-                        destDir, listener, null, it, overwrite) || result
+            encodings.any {
+                unzip(BufferedInputStream(FileInputStream(zipFile)),
+                        destDir, listener, null, it, overwrite)
             }
-            result
         } catch (e: Exception) {
             Log.e(javaClass, "error while unzip", e)
             false
@@ -99,11 +97,13 @@ object ZipHelper {
                 val prevBytesRead = zipInputStream.bytesRead
                 if (encryptor != null) {
                     val result = encryptor.onEncrypt(zipInputStream, out, file.name)
-                    if (result == EncryptResult.FAIL) {
+                    if (isEncryptSuccess(result)) {
+                        if (result == EncryptResult.SUCCESS) {
+                            continue
+                        }
+                    } else {
                         out.close()
                         return false
-                    } else if (result == EncryptResult.SUCCESS) {
-                        continue
                     }
                 }
 
@@ -131,4 +131,6 @@ object ZipHelper {
             zipInputStream.close()
         }
     }
+
+    private fun isEncryptSuccess(encryptResult: EncryptResult): Boolean = (encryptResult == EncryptResult.FAIL).not()
 }

--- a/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
@@ -126,7 +126,7 @@ object ZipHelper {
             zipInputStream.close()
         }
     }
-}
 
-class EncryptionFailedException(fileName: String) : Exception("error while encrypt $fileName")
-class EncryptionUnnecessaryException(fileName: String) : Exception("$fileName is unnecessary for encrypt")
+    class EncryptionFailedException(fileName: String) : Exception("error while encrypt $fileName")
+    class EncryptionUnnecessaryException(fileName: String) : Exception("$fileName is unnecessary for encrypt")
+}

--- a/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/io/ZipHelper.kt
@@ -97,11 +97,9 @@ object ZipHelper {
                 val prevBytesRead = zipInputStream.bytesRead
                 if (encryptor != null) {
                     val result = encryptor.encrypt(zipInputStream, out, file.name)
-                    if (result == EncryptResult.FAIL) {
-                        if (result == EncryptResult.SUCCESS) {
-                            continue
-                        }
-                    } else {
+                    if (result == EncryptResult.SUCCESS) {
+                        continue
+                    } else if (result == EncryptResult.FAIL) {
                         out.close()
                         throw EncryptException(file.name)
                     }


### PR DESCRIPTION
Ridibooks-Android에서 압축을 푸는 동시에 encrypt를 해야하는 상황이 생겨서 함수를 추가했습니다. 

- **unzipEncryptIfNeeded** : 압축을 푸는 파일이 encryption이 필요하면 encrypt를 수행하고 그 결과에 따라 진행합니다. 성공, 실패, (암호화)불필요, 3가지 상태로 나누어져 있습니다. 

- **unzipSelectedFile** : 원하는 파일만 압축을 풀기위해 추가했습니다.