### PR TITLE
킨들 기기의 웹뷰 버전 코드를 가져올 수 있도록 기능 확장

### DIFF
--- a/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
@@ -10,11 +10,6 @@ fun Context.getPackageVersionCode(`package`: String, enabledOnly: Boolean = true
     try {
         val info = packageManager.getPackageInfo(`package`, 0)
         if (enabledOnly.not() || info.applicationInfo.enabled) {
-            if (`package`.startsWith("com.amazon.webview") && info.versionCode / 100000000 < 1) {
-                return info.versionName.split(".").let { parts ->
-                    if (parts.count() < 5) -1 else parts.drop(2).joinToString("").toInt()
-                }
-            }
             return info.versionCode
         }
     } catch (e: PackageManager.NameNotFoundException) {
@@ -31,10 +26,28 @@ fun Context.getSystemWebViewVersionCode(): Int {
         }
     }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        return getPackageVersionCode("com.google.android.webview",
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.N).let { versionCode ->
-            if (versionCode > 0) versionCode else
-                getPackageVersionCode("com.amazon.webview.chromium")
+        val versionCode = getPackageVersionCode("com.google.android.webview",
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        if (versionCode > 0) {
+            return versionCode
+        } else {
+            val `package` = "com.amazon.webview.chromium"
+            try {
+                val info = packageManager.getPackageInfo(`package`, 0)
+                return if (info.versionCode / 100000000 > 0) {
+                    info.versionCode
+                } else {
+                    info.versionName.split(".").let { parts ->
+                        if (parts.count() != 5) {
+                            -1
+                        } else {
+                            parts.drop(2).joinToString("").toInt()
+                        }
+                    }
+                }
+            } catch (e: PackageManager.NameNotFoundException) {
+                Log.d("Failed to get $`package` package info", e)
+            }
         }
     }
     return -1

--- a/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
@@ -13,7 +13,7 @@ fun Context.getPackageVersionCode(name: String, enabledOnly: Boolean = true): In
             return info.versionCode
         }
     } catch (e: PackageManager.NameNotFoundException) {
-        Log.d("Failed to get $name package info", e)
+        Log.d(javaClass, "Failed to get $name package info", e)
     }
     return -1
 }
@@ -46,7 +46,7 @@ fun Context.getSystemWebViewVersionCode(): Int {
                     }
                 }
             } catch (e: PackageManager.NameNotFoundException) {
-                Log.d("Failed to get $packageName package info", e)
+                Log.d(javaClass, "Failed to get $packageName package info", e)
             }
         }
     }

--- a/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
@@ -34,7 +34,7 @@ fun Context.getSystemWebViewVersionCode(): Int {
             val `package` = "com.amazon.webview.chromium"
             try {
                 val info = packageManager.getPackageInfo(`package`, 0)
-                return if (info.versionCode / 100000000 > 0) {
+                return if (info.versionCode >= 100000000) {
                     info.versionCode
                 } else {
                     info.versionName.split(".").let { parts ->

--- a/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
@@ -6,14 +6,14 @@ import android.os.Build
 import com.ridi.books.helper.Log
 
 @JvmOverloads
-fun Context.getPackageVersionCode(`package`: String, enabledOnly: Boolean = true): Int {
+fun Context.getPackageVersionCode(name: String, enabledOnly: Boolean = true): Int {
     try {
-        val info = packageManager.getPackageInfo(`package`, 0)
+        val info = packageManager.getPackageInfo(name, 0)
         if (enabledOnly.not() || info.applicationInfo.enabled) {
             return info.versionCode
         }
     } catch (e: PackageManager.NameNotFoundException) {
-        Log.d("Failed to get $`package` package info", e)
+        Log.d("Failed to get $name package info", e)
     }
     return -1
 }
@@ -31,9 +31,9 @@ fun Context.getSystemWebViewVersionCode(): Int {
         if (versionCode > 0) {
             return versionCode
         } else {
-            val `package` = "com.amazon.webview.chromium"
+            val packageName = "com.amazon.webview.chromium"
             try {
-                val info = packageManager.getPackageInfo(`package`, 0)
+                val info = packageManager.getPackageInfo(packageName, 0)
                 return if (info.versionCode >= 100000000) {
                     info.versionCode
                 } else {
@@ -46,7 +46,7 @@ fun Context.getSystemWebViewVersionCode(): Int {
                     }
                 }
             } catch (e: PackageManager.NameNotFoundException) {
-                Log.d("Failed to get $`package` package info", e)
+                Log.d("Failed to get $packageName package info", e)
             }
         }
     }

--- a/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/system/PackageHelper.kt
@@ -10,6 +10,11 @@ fun Context.getPackageVersionCode(`package`: String, enabledOnly: Boolean = true
     try {
         val info = packageManager.getPackageInfo(`package`, 0)
         if (enabledOnly.not() || info.applicationInfo.enabled) {
+            if (`package`.startsWith("com.amazon.webview") && info.versionCode / 100000000 < 1) {
+                return info.versionName.split(".").let { parts ->
+                    if (parts.count() < 5) -1 else parts.drop(2).joinToString("").toInt()
+                }
+            }
             return info.versionCode
         }
     } catch (e: PackageManager.NameNotFoundException) {
@@ -27,7 +32,10 @@ fun Context.getSystemWebViewVersionCode(): Int {
     }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         return getPackageVersionCode("com.google.android.webview",
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.N).let { versionCode ->
+            if (versionCode > 0) versionCode else
+                getPackageVersionCode("com.amazon.webview.chromium")
+        }
     }
     return -1
 }


### PR DESCRIPTION
- 파이어 OS에 설치된 웹뷰의 `packageName`과 `versionCode`가 커스텀되어 있어 `versionCode`를 가져오지 못하는 문제를 해결하기 위한 PR입니다.
- 파이어 OS에 설치된 웹뷰는 `com.amazon.webview`, `com.amazon.webview.chromium` 이렇게 두 가지로 Chromium 기반입니다.
- 두 웹뷰 모두 `versionCode`의 넘버링이 커스텀되어 있으나, `versionName`은 기존 Chromium과 동일하여 이를 이용해 `versionCode`를 추출하도록 하였습니다.