### PR TITLE
support.v4.Fragment 를 위한 find 와 findLazy 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ android {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'com.android.support:support-compat:26.1.0'
+    compile 'com.android.support:support-fragment:26.1.0'
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'jp.co.cyberagent.android.gpuimage:gpuimage-library:1.4.1'
     compile 'org.apache.commons:commons-compress:1.12'
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'com.android.support:support-compat:26.1.0'
     compile 'com.google.code.gson:gson:2.8.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'jp.co.cyberagent.android.gpuimage:gpuimage-library:1.4.1'
     compile 'org.apache.commons:commons-compress:1.12'
     testImplementation 'junit:junit:4.12'

--- a/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
@@ -22,6 +22,9 @@ fun <T : View?> View.find(@IdRes viewId: Int) = findViewById<T>(viewId) as T
 fun <T : View?> Fragment.find(@IdRes viewId: Int) = view.findViewById<T>(viewId) as T
 
 @Suppress("UNCHECKED_CAST")
+fun <T : View?> android.support.v4.app.Fragment.find(@IdRes viewId: Int) = view!!.findViewById<T>(viewId) as T
+
+@Suppress("UNCHECKED_CAST")
 fun <T : View?> Activity.find(@IdRes viewId: Int) = findViewById<T>(viewId) as T
 
 @Suppress("UNCHECKED_CAST")
@@ -38,6 +41,9 @@ fun <T : View?> Dialog.findLazy(@IdRes viewId: Int) = lazy { find<T>(viewId) }
 
 @Suppress("UNCHECKED_CAST")
 fun <T : View?> View.findLazy(@IdRes viewId: Int) = lazy { find<T>(viewId) }
+
+@Suppress("UNCHECKED_CAST")
+fun <T: View?> android.support.v4.app.Fragment.findLazy(@IdRes viewId: Int) = lazy { find<T>(viewId) }
 
 @Px fun Context.dip(@Dp value: Int) = dip(value.toFloat())
 


### PR DESCRIPTION
support.v4.Fragment의 find와 findLazy함수를 추가했습니다.

왜인지 support.v4.Fragment의 getView에서 view가 널체크를 해줘야 하는데 널일 경우가 없을 것 같아서
 !!(non-null) 처리를 해주었습니다.