### PR TITLE
view의 모습을 bitmap으로 담아내는 함수 추가

### DIFF
--- a/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
@@ -3,6 +3,8 @@ package com.ridi.books.helper.view
 import android.app.Activity
 import android.app.Dialog
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.util.TypedValue
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
@@ -128,4 +130,14 @@ fun ViewGroup.logChildren() {
             }
     }
     logChildrenRecursively(0)
+}
+
+fun View.drawToBitmap(isHighQuality: Boolean = true): Bitmap {
+    val bitmap = Bitmap.createBitmap(
+        width,
+        height,
+        if (isHighQuality) Bitmap.Config.ARGB_8888 else Bitmap.Config.RGB_565
+    )
+    draw(Canvas(bitmap))
+    return bitmap
 }


### PR DESCRIPTION
## 개요
- view에서 렌더링되는 모습을 bitmap으로 담아내는 기능을 추가하였습니다.
- 관련이슈 : [Ridibooks-android:PR#192](https://github.com/ridi/Ridibooks-Android/pull/201)

## 작업내역
### drawToBitmap 함수 추가
- `drawingCache`보다 약간 성능이 떨어지지만 대다수의 경우 대체할 수 있습니다.
- `isHighQuality`에 따라 `RGB_565` `ARGB_8888` 중 하나로 렌더링합니다.
