### PR TITLE
뷰 사이즈가 0일경우 null을 리턴하도록 추가

### DIFF
--- a/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
@@ -132,7 +132,9 @@ fun ViewGroup.logChildren() {
     logChildrenRecursively(0)
 }
 
-fun View.drawToBitmap(isHighQuality: Boolean = true): Bitmap {
+fun View.drawToBitmap(isHighQuality: Boolean = true): Bitmap? {
+    if (width == 0 || height == 0) return null
+
     val bitmap = Bitmap.createBitmap(
         width,
         height,


### PR DESCRIPTION
## 개요
- view size가 0일때 `IllegalArgumentException`가 발생하는 오류가 있습니다.

null을 리턴하도록 변경하였습니다.