### PR TITLE
dp / px 변환시 소수점까지 무시하지 않고 계산하는 기능 추가

### DIFF
--- a/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
@@ -54,21 +54,13 @@ fun <T : View?> View.findLazy(@IdRes viewId: Int) = lazy { find<T>(viewId) }
 @Suppress("UNCHECKED_CAST")
 fun <T : View?> Fragment.findLazy(@IdRes viewId: Int) = lazy { find<T>(viewId) }
 
-@Px fun Context.dip(@Dp value: Int) = dip(value.toFloat())
+fun Context.dip(@Dp value: Number) = value.toFloat() * resources.displayMetrics.density
 
-@Px fun View.dip(@Dp value: Int) = context.dip(value)
+fun View.dip(@Dp value: Number) = context.dip(value)
 
-@Px fun Context.dip(@Dp value: Float) = Math.round(value * resources.displayMetrics.density)
+@Dp fun Context.px(value: Number) = value.toFloat() / resources.displayMetrics.density
 
-@Px fun View.dip(@Dp value: Float) = context.dip(value)
-
-@Dp fun Context.px(@Px value: Int) = px(value.toFloat())
-
-@Dp fun View.px(@Px value: Int) = context.px(value)
-
-@Dp fun Context.px(@Px value: Float) = Math.round(value / resources.displayMetrics.density)
-
-@Dp fun View.px(@Px value: Float) = context.px(value)
+@Dp fun View.px(value: Number) = context.px(value)
 
 @Px fun Context.dimen(@DimenRes resId: Int) = resources.getDimensionPixelSize(resId)
 

--- a/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
@@ -27,6 +27,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.ridi.books.helper.Log
 import com.ridi.books.helper.annotation.Dp
+import kotlin.math.roundToInt
 
 fun ViewGroup.inflate(@LayoutRes resId: Int): View = LayoutInflater.from(context).inflate(resId, this)
 
@@ -58,17 +59,39 @@ fun <T : View?> Fragment.findLazy(@IdRes viewId: Int) = lazy { find<T>(viewId) }
 
 @Px fun View.dip(@Dp value: Int) = context.dip(value)
 
-@Px fun Context.dip(@Dp value: Float) = Math.round(value * resources.displayMetrics.density)
+@Px fun Context.dip(@Dp value: Float) = dip(value, false).toInt()
 
 @Px fun View.dip(@Dp value: Float) = context.dip(value)
+
+fun Context.dip(@Dp value: Int, accurate: Boolean) = dip(value.toFloat(), accurate)
+
+fun View.dip(@Dp value: Int, accurate: Boolean) = context.dip(value.toFloat(), accurate)
+
+fun Context.dip(@Dp value: Float, accurate: Boolean): Float {
+    val result = value * resources.displayMetrics.density
+    return if (accurate) result else result.roundToInt().toFloat()
+}
+
+fun View.dip(@Dp value: Float, sharp: Boolean) = context.dip(value, sharp)
 
 @Dp fun Context.px(@Px value: Int) = px(value.toFloat())
 
 @Dp fun View.px(@Px value: Int) = context.px(value)
 
-@Dp fun Context.px(@Px value: Float) = Math.round(value / resources.displayMetrics.density)
+@Dp fun Context.px(@Px value: Float) = px(value, false).toInt()
 
 @Dp fun View.px(@Px value: Float) = context.px(value)
+
+@Dp fun Context.px(@Px value: Int, accurate: Boolean) = px(value.toFloat(), accurate)
+
+@Dp fun View.px(@Px value: Int, accurate: Boolean) = context.px(value.toFloat(), accurate)
+
+@Dp fun Context.px(@Px value: Float, accurate: Boolean): Float {
+    val result = value / resources.displayMetrics.density
+    return if (accurate) result else result.roundToInt().toFloat()
+}
+
+@Dp fun View.px(@Px value: Float, sharp: Boolean) = context.px(value, sharp)
 
 @Px fun Context.dimen(@DimenRes resId: Int) = resources.getDimensionPixelSize(resId)
 

--- a/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/view/ViewHelper.kt
@@ -27,7 +27,6 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.ridi.books.helper.Log
 import com.ridi.books.helper.annotation.Dp
-import kotlin.math.roundToInt
 
 fun ViewGroup.inflate(@LayoutRes resId: Int): View = LayoutInflater.from(context).inflate(resId, this)
 
@@ -59,39 +58,17 @@ fun <T : View?> Fragment.findLazy(@IdRes viewId: Int) = lazy { find<T>(viewId) }
 
 @Px fun View.dip(@Dp value: Int) = context.dip(value)
 
-@Px fun Context.dip(@Dp value: Float) = dip(value, false).toInt()
+@Px fun Context.dip(@Dp value: Float) = Math.round(value * resources.displayMetrics.density)
 
 @Px fun View.dip(@Dp value: Float) = context.dip(value)
-
-fun Context.dip(@Dp value: Int, accurate: Boolean) = dip(value.toFloat(), accurate)
-
-fun View.dip(@Dp value: Int, accurate: Boolean) = context.dip(value.toFloat(), accurate)
-
-fun Context.dip(@Dp value: Float, accurate: Boolean): Float {
-    val result = value * resources.displayMetrics.density
-    return if (accurate) result else result.roundToInt().toFloat()
-}
-
-fun View.dip(@Dp value: Float, sharp: Boolean) = context.dip(value, sharp)
 
 @Dp fun Context.px(@Px value: Int) = px(value.toFloat())
 
 @Dp fun View.px(@Px value: Int) = context.px(value)
 
-@Dp fun Context.px(@Px value: Float) = px(value, false).toInt()
+@Dp fun Context.px(@Px value: Float) = Math.round(value / resources.displayMetrics.density)
 
 @Dp fun View.px(@Px value: Float) = context.px(value)
-
-@Dp fun Context.px(@Px value: Int, accurate: Boolean) = px(value.toFloat(), accurate)
-
-@Dp fun View.px(@Px value: Int, accurate: Boolean) = context.px(value.toFloat(), accurate)
-
-@Dp fun Context.px(@Px value: Float, accurate: Boolean): Float {
-    val result = value / resources.displayMetrics.density
-    return if (accurate) result else result.roundToInt().toFloat()
-}
-
-@Dp fun View.px(@Px value: Float, sharp: Boolean) = context.px(value, sharp)
 
 @Px fun Context.dimen(@DimenRes resId: Int) = resources.getDimensionPixelSize(resId)
 


### PR DESCRIPTION
## 개요
dp <-> px 변환시에 기존엔 반올림이 기본 정책이었으나
정밀한 애니메이션이 필요한 경우 정확한 소수 결과가 필요할 수 있어
정확한 결과를 출력해주는 옵션이 `accurate`를 추가하였습니다.

## 기타
구현부가 조금 복잡한데요 😓 
return type이 Float인 함수만 하나 추가하면 되는 간단한 작업인데,
kotlin 에서도 return type으로는 overloading이 안되서 인자를 다르게 하여 구현하였습니다.