### PR TITLE
`<`, `>`로 감싸져있는 본문 텍스트를 보존할 수 있는 함수 추가

### DIFF
--- a/src/main/kotlin/com/ridi/books/helper/text/HtmlHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/text/HtmlHelper.kt
@@ -1,33 +1,23 @@
 package com.ridi.books.helper.text
 
 import android.os.Build
+import android.text.Editable
 import android.text.Html
 import android.text.Spanned
+import org.xml.sax.XMLReader
 
 fun makeSpannedFromHtml(htmlText: String): Spanned {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        Html.fromHtml(htmlText, Html.FROM_HTML_MODE_LEGACY)
-    } else {
-        @Suppress("DEPRECATION")
-        Html.fromHtml(htmlText)
-    }
+    return makeSpannedFromHtml(htmlText, null)
 }
 
-fun makeSpannedFromHtmlWithLtGtPreserved(htmlText: String): Spanned {
-    // EPUB 본문 텍스트에 사용된 &lt; &gt;를 처리하기 위한 목적으로 만들어졌기 때문에 closing인 경우는 고려하지 않음
-    // Close되지 않은 unknown tag에 대해 일괄적으로 closing처리가 되는데 이 경우는 따로 처라히지 않음
+fun makeSpannedFromHtml(
+    htmlText: String,
+    tagHandler: ((opening: Boolean, tag: String, output: Editable, xmlReader: XMLReader) -> Unit)?
+): Spanned {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        Html.fromHtml(htmlText, Html.FROM_HTML_MODE_LEGACY, null) { opening, tag, output, _ ->
-            if (opening) {
-                output.append("<$tag>")
-            }
-        }
+        Html.fromHtml(htmlText, Html.FROM_HTML_MODE_LEGACY, null, tagHandler)
     } else {
         @Suppress("DEPRECATION")
-        Html.fromHtml(htmlText, null) { opening, tag, output, _ ->
-            if (opening) {
-                output.append("<$tag>")
-            }
-        }
+        Html.fromHtml(htmlText, null, tagHandler)
     }
 }

--- a/src/main/kotlin/com/ridi/books/helper/text/HtmlHelper.kt
+++ b/src/main/kotlin/com/ridi/books/helper/text/HtmlHelper.kt
@@ -12,3 +12,22 @@ fun makeSpannedFromHtml(htmlText: String): Spanned {
         Html.fromHtml(htmlText)
     }
 }
+
+fun makeSpannedFromHtmlWithLtGtPreserved(htmlText: String): Spanned {
+    // EPUB 본문 텍스트에 사용된 &lt; &gt;를 처리하기 위한 목적으로 만들어졌기 때문에 closing인 경우는 고려하지 않음
+    // Close되지 않은 unknown tag에 대해 일괄적으로 closing처리가 되는데 이 경우는 따로 처라히지 않음
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        Html.fromHtml(htmlText, Html.FROM_HTML_MODE_LEGACY, null) { opening, tag, output, _ ->
+            if (opening) {
+                output.append("<$tag>")
+            }
+        }
+    } else {
+        @Suppress("DEPRECATION")
+        Html.fromHtml(htmlText, null) { opening, tag, output, _ ->
+            if (opening) {
+                output.append("<$tag>")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
관련 CS: [Asana](https://app.asana.com/0/72323656602719/1136286097467601)

`makeSpannedFromHtml`은 기본적으로 인식되지 않는 tag를 제거하게 되어있는데, 본문 텍스트 처리 시  `<`, `>`로 감싸져있는 본문 텍스트가 인식되지 않는 tag로 처리되면서 팝업 주석 사용 시에 해당 내용이 누락되는 문제가 발생하여 tag 처리 방식을 달리한 함수를 추가하였습니다.